### PR TITLE
FIX: NAV-64 Remove filter on parent stop id

### DIFF
--- a/naviqore_viewer/naviqore_viewer/client.py
+++ b/naviqore_viewer/naviqore_viewer/client.py
@@ -40,13 +40,9 @@ def getConnections(
 def getStops() -> dict[str, str]:
     client = getClient()
     stops = client.nearestStops(
-        Coordinate(latitude=47.5, longitude=8.5), limit=INFINITY, maxDistance=INFINITY
+        Coordinate(latitude=47, longitude=8), limit=INFINITY, maxDistance=INFINITY
     )
-    return {
-        stop_distance.stop.id: stop_distance.stop.name
-        for stop_distance in stops
-        if not stop_distance.stop.id.startswith("Parent")
-    }
+    return {stop_distance.stop.id: stop_distance.stop.name for stop_distance in stops}
 
 
 @st.cache_data


### PR DESCRIPTION
Fix the filter on parent stops.

It works, but start up is reaaaaally slow... the nearest neighbour query on large areas is very inefficient. Maybe we add a getStops() method on the schedule controller which returns all stops. But also this is not ideal, since streamlit seems to have some problems with a big about of stops in the input.

But for the demo it should work :)
![Screenshot 2024-06-05 at 14 16 59](https://github.com/naviqore/public-transit-viewer/assets/29773509/60734852-be3f-4570-80c5-571125f2637d)

